### PR TITLE
Fix issue #10: IIJmioTrblBot now properly shows red circle for ongoing issues

### DIFF
--- a/IIJmioTrblBot.sh
+++ b/IIJmioTrblBot.sh
@@ -2,14 +2,40 @@
 set -u
 red=🔴
 green=🟢
-url="https://www.iijmio.jp"$(curl -s -S https://www.iijmio.jp/info/trouble/ | grep "障害発生報告" | head -1 | sed -E -e "s/.+<a href=\"([^\"]+)\">.+/\\1/")
-content=$(curl -s -S "$url" | sed -E -e "s/<[^>]+>//g" -e "s/-->//" -e "s/^\\s+//" -e "/^$/d" -e "s/。ご迷惑を.+/。/" | awk "/^下記に示します/,/^影響サービス/;/^現象/,/^備考/" | grep -v -E -e "^＜ 記 ＞" -e "^影響サービス" -e "^備考|^以上" | tr "\n" "_" | sed "s/:_/：/g" | tr "_" "\n")
 
-# Check if the issue is resolved or ongoing
-if echo "$content" | grep -q "対応作業により障害は解消\|正常な状態にて運用中\|復旧いたしました"; then
-    echo "$content" | sed -E -e "s/(下記に示します内容の障害が発生いたしました。)/$green\\1/"
-elif echo "$content" | grep -q "対応作業中\|調査中"; then
-    echo "$content" | sed -E -e "s/(下記に示します内容の障害が発生いたしました。)/$red\\1/"
+# Get multiple recent trouble report URLs (check last 5 reports)
+urls=$(curl -s -S https://www.iijmio.jp/info/trouble/ | grep "障害発生報告" | head -5 | sed -E -e "s/.+<a href=\"([^\"]+)\">.+/https:\/\/www.iijmio.jp\\1/")
+
+all_content=""
+has_ongoing_issues=false
+
+# Check each recent trouble report
+for url in $urls; do
+    content=$(curl -s -S "$url" | sed -E -e "s/<[^>]+>//g" -e "s/-->//" -e "s/^\\s+//" -e "/^$/d" -e "s/。ご迷惑を.+/。/" | awk "/^下記に示します/,/^影響サービス/;/^現象/,/^備考/" | grep -v -E -e "^＜ 記 ＞" -e "^影響サービス" -e "^備考|^以上" | tr "\n" "_" | sed "s/:_/：/g" | tr "_" "\n")
+    
+    # Check if this report has ongoing issues
+    if echo "$content" | grep -q "対応作業中\|調査中"; then
+        has_ongoing_issues=true
+        # Only include reports with ongoing issues in the output
+        if [ -n "$all_content" ]; then
+            all_content="$all_content
+
+$content"
+        else
+            all_content="$content"
+        fi
+    fi
+done
+
+# If no ongoing issues found, show the most recent report (resolved)
+if [ "$has_ongoing_issues" = false ]; then
+    latest_url=$(echo "$urls" | head -1)
+    all_content=$(curl -s -S "$latest_url" | sed -E -e "s/<[^>]+>//g" -e "s/-->//" -e "s/^\\s+//" -e "/^$/d" -e "s/。ご迷惑を.+/。/" | awk "/^下記に示します/,/^影響サービス/;/^現象/,/^備考/" | grep -v -E -e "^＜ 記 ＞" -e "^影響サービス" -e "^備考|^以上" | tr "\n" "_" | sed "s/:_/：/g" | tr "_" "\n")
+fi
+
+# Apply appropriate status indicator
+if [ "$has_ongoing_issues" = true ]; then
+    echo "$all_content" | sed -E -e "s/(下記に示します内容の障害が発生いたしました。)/$red\\1/"
 else
-    echo "$content" | sed -E -e "s/(下記に示します内容の障害が発生いたしました。)/$green\\1/"
+    echo "$all_content" | sed -E -e "s/(下記に示します内容の障害が発生いたしました。)/$green\\1/"
 fi


### PR DESCRIPTION
## Summary
This PR fixes issue #10 where IIJmioTrblBot was not showing the red circle (🔴) when there were ongoing issues.

## Changes Made
- Modified `IIJmioTrblBot.sh` to check the last 5 trouble reports instead of just the most recent one
- Now properly detects ongoing issues across multiple recent reports
- Shows red circle (🔴) when any recent report contains ongoing issues (対応作業中 or 調査中)
- Aggregates all ongoing issues in a single output
- Falls back to showing the most recent report with green circle when no ongoing issues are found

## Problem Solved
Previously, the bot only checked the most recent trouble report. If that report was resolved but there were ongoing issues in other recent reports, the bot would incorrectly show a green circle. Now it properly scans multiple recent reports to detect any ongoing issues.

## Testing
- Verified that resolved issues show green circle (🔴)
- Verified that ongoing issues show red circle (🔴) 
- Tested with simulated content matching the issue description

Fixes #10