### PR TITLE
Fix issue #17: Add Go cache to speed up shfmt workflow

### DIFF
--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
+        cache: true
         
     - name: Install shfmt
       run: go install mvdan.cc/sh/v3/cmd/shfmt@latest


### PR DESCRIPTION
shfmtのGitHub Actionsの実行時間を短縮するため、Goキャッシュを有効にしました。

## 変更内容
- `actions/setup-go@v5`で`cache: true`を追加
- Goモジュールとビルドキャッシュがワークフロー実行間で保持される
- 20秒かかっていた実行時間が大幅に短縮される予定

## 効果
- 初回実行後はGoの依存関係がキャッシュされる
- shfmtのインストール時間が短縮される
- 全体的なCI/CD実行時間の改善

Resolves #17