### PR TITLE
Fix: Use orange emoji for IIJmio issues under investigation with normal operation

### DIFF
--- a/IIJmioTrblBot.sh
+++ b/IIJmioTrblBot.sh
@@ -25,7 +25,13 @@ if [ -z "$content" ] || ! grep -q "下記に示します" <<<"$content"; then
 fi
 
 # Check if the issue is resolved or ongoing
-if echo "$content" | grep -q "対応作業中\|調査中"; then
+if echo "$content" | grep -q "対応作業中"; then
+	echo "${red}下記に示します内容の障害が発生いたしました。"
+	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
+elif echo "$content" | grep -q "調査中" && echo "$content" | grep -q "正常な状態"; then
+	echo "${orange}下記に示します内容の障害が発生いたしました。"
+	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
+elif echo "$content" | grep -q "調査中"; then
 	echo "${red}下記に示します内容の障害が発生いたしました。"
 	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
 else

--- a/IIJmioTrblBot.sh
+++ b/IIJmioTrblBot.sh
@@ -2,6 +2,7 @@
 set -u
 red=🔴
 green=🟢
+orange=🟠
 url="https://www.iijmio.jp"$(curl -s -S https://www.iijmio.jp/info/trouble/ | grep "障害発生報告" | head -1 | sed -E -e "s/.+<a href=\"([^\"]+)\">.+/\\1/")
 
 # Get raw content and save to timestamped log file


### PR DESCRIPTION
Fixes #29

## Changes
- Updated `IIJmioTrblBot.sh` to use orange (🟠) emoji when:
  - Cause is "調査中" (under investigation) AND
  - Current status shows "正常な状態" (normal operation)
- Added missing `orange=🟠` variable declaration

## Logic
The new emoji logic is:
1. 🔴 Red: "対応作業中" (work in progress) - active issues
2. 🟠 Orange: "調査中" + "正常な状態" - cause unknown but service working normally  
3. 🔴 Red: "調査中" without "正常な状態" - cause unknown and service affected
4. 🟢 Green: All other cases (resolved issues)

## Testing
- Verified the logic works correctly for all scenarios with test cases
- Maintains backward compatibility for existing functionality
- Fixed undefined variable issue by adding orange variable declaration

This addresses the specific case mentioned in issue #29 where the service is operating normally but the root cause is still under investigation, which should be indicated with orange rather than red.