### PR TITLE
Fix Gemini Automated Issue Triage workflow errors

### DIFF
--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -79,29 +79,26 @@ jobs:
           fi
           
           # Create a prompt for code review
-          cat > final_prompt.txt << EOF
+          cat > final_prompt.txt << 'EOF'
           ## Role
           You are an issue triage assistant. Analyze the current GitHub issue
           and apply the most appropriate existing labels. Use the available
           tools to gather information; do not ask for information to be
           provided.
           ## Steps
-          1. Run: `gh label list` to get all available labels.
+          1. Run: `gh api repos/:owner/:repo/labels --jq '.[].name'` to get all available labels.
           2. Review the issue title and body provided in the environment
              variables: "${ISSUE_TITLE}" and "${ISSUE_BODY}".
-          3. Select the most relevant labels from the existing labels. If
-             available, set labels that follow the `kind/*`, `area/*`, and
-             `priority/*` patterns.
+          3. Select the most relevant labels from the existing labels. Available labels are:
+             bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix
           4. Apply the selected labels to this issue using:
              `gh issue edit "${ISSUE_NUMBER}" --add-label "label1,label2"`
-          5. If the "status/needs-triage" label is present, remove it using:
-             `gh issue edit "${ISSUE_NUMBER}" --remove-label "status/needs-triage"`
           ## Guidelines
           - Only use labels that already exist in the repository
           - Do not add comments or modify the issue content
           - Triage only the current issue
           - Assign all applicable labels based on the issue content
-          - Reference all shell variables as "${VAR}" (with quotes and braces)
+          - Reference all shell variables with quotes and braces like "${VARIABLE_NAME}"
           EOF
           
           # Run Gemini


### PR DESCRIPTION
## Problem
The Gemini Automated Issue Triage workflow (issue #32) was failing with multiple errors:

1. **Unbound variable error**: `${VAR}` reference in prompt template
2. **Invalid command**: `gh label list` doesn't exist
3. **Missing labels**: References to non-existent labels like `kind/*`, `area/*`, `priority/*`, `status/needs-triage`

## Solution
- Fixed unbound variable error by using quoted heredoc delimiter (`'EOF'`)
- Replaced `gh label list` with correct API call: `gh api repos/:owner/:repo/labels --jq '.[].name'`
- Removed references to non-existent labels
- Listed actual available labels in the repository: bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix
- Simplified prompt instructions to focus on existing labels

## Testing
The workflow can be tested with:
```bash
gh workflow run "🏷️ Gemini Automated Issue Triage" --field issue_number=31
```

Fixes #32