### PR TITLE
fix(iijmiotrblbot): correct status header and resolution detection (fixes #30)

### DIFF
--- a/IIJmioTrblBot.sh
+++ b/IIJmioTrblBot.sh
@@ -5,37 +5,31 @@ green=🟢
 orange=🟠
 url="https://www.iijmio.jp"$(curl -s -S https://www.iijmio.jp/info/trouble/ | grep "障害発生報告" | head -1 | sed -E -e "s/.+<a href=\"([^\"]+)\">.+/\\1/")
 
-# Get raw content and save to timestamped log file
 raw_content=$(curl -s -S "$url")
 timestamp=$(date +"%Y%m%d-%H%M%S")
 log_file="iijmiotrblbot-${timestamp}.log"
 
-# Check if content is different from the most recent log file
 latest_log=$(ls -t iijmiotrblbot-*.log 2>/dev/null | head -1)
 if ! [ -f "$latest_log" ] || ! printf "%s" "$raw_content" | diff -q "$latest_log" - >/dev/null 2>&1; then
-	# Content is different or no previous log exists, save new log file
 	printf "%s" "$raw_content" >"$log_file"
 fi
 
 content=$(printf "%s" "$raw_content" | sed -E -e "s/<[^>]+>//g" -e "s/-->//" -e "s/^\s+//" -e "/^$/d" -e "s/。ご迷惑を.+/。/" | awk "/^下記に示します/,/^影響サービス/;/^現象/,/^備考/" | grep -v -E -e "^＜ 記 ＞" -e "^影響サービス" -e "^備考|^以上" | tr "\n" "_" | sed "s/:_/：/g" | tr "_" "\n")
 
-# Check if content is empty or invalid
 if [ -z "$content" ] || ! grep -q "下記に示します" <<<"$content"; then
-	# Don't post anything if content is empty or doesn't contain expected text
 	exit 0
 fi
 
-# Check if the issue is resolved or ongoing
 if echo "$content" | grep -q "対応作業中"; then
-	echo "${red}下記に示します内容の障害が発生いたしました。"
+	echo "${red}下記に示します内容の障害が発生しています。"
 	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
-elif echo "$content" | grep -q "調査中" && echo "$content" | grep -q "正常な状態"; then
-	echo "${orange}下記に示します内容の障害が発生いたしました。"
+elif echo "$content" | grep -q "調査中" && ! echo "$content" | grep -q "正常な状態"; then
+	echo "${red}下記に示します内容の障害が発生しています（調査中）。"
 	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
-elif echo "$content" | grep -q "調査中"; then
-	echo "${red}下記に示します内容の障害が発生いたしました。"
+elif echo "$content" | grep -q "復旧\|解消\|正常な状態"; then
+	echo "${green}下記に示します内容の障害は復旧しました。"
 	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
 else
-	echo "${green}下記に示します内容の障害が発生いたしました。"
+	echo "${orange}下記に示します内容の障害が発生しました。"
 	echo "$content" | grep -v "^下記に示します内容の障害が発生いたしました。"
 fi


### PR DESCRIPTION
This PR fixes the IIJmio trouble bot message logic.\n\nProblem (issue #30)\n- When an incident is already resolved, the bot still posted a green message with the phrase "障害が発生いたしました" which is misleading.\n- Logs (iijmiotrblbot-*.log) show the page includes "正常な状態" after recovery.\n\nChanges\n- Refine state detection: \n  - ongoing: ⛳ red with "発生しています" (and for 調査中).\n  - resolved: green with "復旧しました" if it contains 復旧/解消/正常な状態.\n  - otherwise: orange generic incident.\n- Keep raw parsing but simplify conditions; also keep timestamped logs for diffing as before.\n\nVerification\n- Ran IIJmioTrblBot.sh locally against archived HTML; output now shows green "障害は復旧しました。" and correct fields.\n\nThis should address and close #30.