### PR TITLE
Fix heredoc variable expansion in Gemini scheduled triage workflow

### DIFF
--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -87,7 +87,7 @@ jobs:
           fi
           
           # Create a prompt for code review
-          cat > final_prompt.txt << EOF
+          cat > final_prompt.txt << 'EOF'
           ## Role
           You are an issue triage assistant. Analyze issues and apply
           appropriate labels. Use the available tools to gather information;


### PR DESCRIPTION
## Problem
The Gemini scheduled triage workflow was failing with 'unbound variable' errors because the heredoc in the workflow was not quoted, causing shell variables like `${ISSUE_NUMBER}` to be expanded by bash instead of being passed literally to the Gemini CLI.

## Solution
Changed the heredoc from `EOF` to quoted `'EOF'` to prevent variable expansion.

## Error Log


## Testing
This fix ensures that the prompt text is passed literally to the Gemini CLI without shell variable expansion.

Fixes the failing workflow: https://github.com/zenjiro/zenjiro-bot-oci/actions/runs/16905906749/job/47895526573