### PR TITLE
Add Japanese job summaries and fix heredoc variable expansion

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -238,7 +238,7 @@ jobs:
           fi
           
           # Create a prompt for code review
-          cat > final_prompt.txt << EOF
+          cat > final_prompt.txt << 'EOF'
           ## Role
           You are a helpful AI assistant invoked via a CLI interface in a GitHub workflow. You have access to tools to interact with the repository and respond to the user.
           ## Context
@@ -330,7 +330,17 @@ jobs:
           REPOSITORY: '${{ github.repository }}'
         run: |-
           set -euo pipefail
-          MESSAGE=" Oops! Something went wrong while processing your request. Please check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          MESSAGE=" 問題が発生しました。詳細は [アクションのログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) をご確認ください。"
           gh issue comment "${ISSUE_NUMBER}" \
             --body "${MESSAGE}" \
             --repo "${REPOSITORY}"
+
+      - name: 'Post Japanese Job Summary'
+        run: |-
+          set -euo pipefail
+          {
+            echo "## Gemini CLI 実行概要"
+            echo ""
+            echo "- すべての応答・コメントは日本語で投稿されます"
+            echo "- 失敗時のエラーメッセージも日本語で通知されます"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -165,7 +165,7 @@ jobs:
           fi
           
           # Create a prompt for code review
-          cat > final_prompt.txt << EOF
+          cat > final_prompt.txt << 'EOF'
           You are an expert code reviewer. Please review the following pull request changes and provide constructive feedback.
 
           ## Pull Request Information
@@ -233,6 +233,26 @@ jobs:
               issue_number: parseInt(prNumber),
               body: comment
             });
+
+      - name: 'Post Japanese Job Summary'
+        env:
+          PR_NUMBER: '${{ steps.get_pr.outputs.pr_number }}'
+          PR_DATA: '${{ steps.get_pr.outputs.pr_data }}'
+        run: |-
+          set -euo pipefail
+          CHANGED_FILES=$(echo "${PR_DATA}" | jq -r '.changedFiles // empty')
+          ADDITIONS=$(echo "${PR_DATA}" | jq -r '.additions // empty')
+          DELETIONS=$(echo "${PR_DATA}" | jq -r '.deletions // empty')
+          {
+            echo "## Gemini レビュー概要"
+            echo ""
+            echo "- PR番号: ${PR_NUMBER}"
+            echo "- 変更ファイル数: ${CHANGED_FILES}"
+            echo "- 追加行: ${ADDITIONS}"
+            echo "- 削除行: ${DELETIONS}"
+            echo ""
+            echo "詳細なレビューはこのPRのコメントに投稿しました。"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: 'Post PR review failure comment'
         if: |-


### PR DESCRIPTION
## 変更内容

### 日本語ジョブサマリの追加
- **PR Review Workflow**: レビュー概要（PR番号、変更ファイル数、追加・削除行数）を日本語で表示
- **CLI Workflow**: 実行概要を日本語で表示
- **失敗メッセージ**: CLI workflowでの失敗時エラーメッセージを日本語に変更

### Heredoc修正
- **PR Review Workflow**: `cat > final_prompt.txt << EOF` → `cat > final_prompt.txt << 'EOF'`
- **CLI Workflow**: `cat > final_prompt.txt << EOF` → `cat > final_prompt.txt << 'EOF'`

## 効果
- GitHub Actions の Job Summary が日本語で表示されるようになります
- 全ての Gemini 関連の出力が一貫して日本語になります
- Heredoc でのシェル変数展開エラーを防止します

## テスト
- PR作成後、レビューワークフローが自動実行され、日本語サマリが確認できます
- CLI workflowは `@gemini-cli` でのコメント時に日本語サマリが表示されます

関連: #40 (heredoc修正の続き)