### PR TITLE
Fix issue #28: Handle date/time changes as white alerts instead of red

### DIFF
--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -3,6 +3,13 @@
 set -u
 red=🔴
 green=🟢
+orange=🟠
 result=$(curl -s -S "https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href="([^"]+)".+/\1/')/" | grep '<h1 class="p-template__type1">' -A 20 | sed -E -e "s/(<br>)+/\n/g" -e "s/^\\s+//" -e "s/<[^>]+>//g" -e "/^$/d" | tail -n +3)
-tail -2 <<<"$result" | grep 回復済み >/dev/null && echo -n "$green" || echo -n "$red"
+if tail -2 <<<"$result" | grep 回復済み >/dev/null; then
+    echo -n "$green"
+elif echo "$result" | grep -E "(発生日時.*変更|変更.*発生日時|■変更前|■変更後|日時.*変更.*いたしました)" >/dev/null; then
+    echo -n "$orange"
+else
+    echo -n "$red"
+fi
 head -n -6 <<<"$result"

--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -3,12 +3,12 @@
 set -u
 red=🔴
 green=🟢
-orange=🟠
+white=⚪
 result=$(curl -s -S "https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href="([^"]+)".+/\1/')/" | grep '<h1 class="p-template__type1">' -A 20 | sed -E -e "s/(<br>)+/\n/g" -e "s/^\\s+//" -e "s/<[^>]+>//g" -e "/^$/d" | tail -n +3)
 if tail -2 <<<"$result" | grep 回復済み >/dev/null; then
     echo -n "$green"
 elif echo "$result" | grep -E "(発生日時.*変更|変更.*発生日時|■変更前|■変更後|日時.*変更.*いたしました)" >/dev/null; then
-    echo -n "$orange"
+    echo -n "$white"
 else
     echo -n "$red"
 fi

--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -6,10 +6,10 @@ green=🟢
 white=⚪
 result=$(curl -s -S "https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href="([^"]+)".+/\1/')/" | grep '<h1 class="p-template__type1">' -A 20 | sed -E -e "s/(<br>)+/\n/g" -e "s/^\\s+//" -e "s/<[^>]+>//g" -e "/^$/d" | tail -n +3)
 if tail -2 <<<"$result" | grep 回復済み >/dev/null; then
-    echo -n "$green"
+	echo -n "$green"
 elif echo "$result" | grep -E "(発生日時.*変更|変更.*発生日時|■変更前|■変更後|日時.*変更.*いたしました)" >/dev/null; then
-    echo -n "$white"
+	echo -n "$white"
 else
-    echo -n "$red"
+	echo -n "$red"
 fi
 head -n -6 <<<"$result"


### PR DESCRIPTION
## Summary
Fixes issue #28 where OcnMobileOneBot incorrectly treats administrative date/time changes as outage information.

## Changes
- Added white circle emoji (⚪) for administrative updates
- Enhanced logic to detect date/time change patterns:
  - `発生日時.*変更` or `変更.*発生日時`
  - `■変更前` and `■変更後` markers
  - `日時.*変更.*いたしました` phrases
- Now uses white alert for date/time corrections instead of red outage alert
- Maintains existing behavior: red for actual outages, green for recovered status

## Alert System
- 🟢 **Green**: Recovered status (contains "回復済み")
- ⚪ **White**: Administrative updates (date/time changes) - neutral/informational
- 🔴 **Red**: Actual outages

## Testing
- Tested with simulated date/time change content (outputs white ⚪)
- Tested with actual outage content (outputs red 🔴)
- Tested with recovered status (outputs green 🟢)
- Verified current live data still works correctly

## Example
Before: Date/time changes would show `🔴【更新】発生日時を...変更いたしました`
After: Date/time changes now show `⚪【更新】発生日時を...変更いたしました`

Closes #28