### PR TITLE
feat(ocnmobileonebot): add raw HTML logging with content-diffing

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -178,6 +178,8 @@ export $(xargs < environment) && ./run-all.sh
     - resolved: green with "障害は復旧しました" if content contains 復旧/解消/正常な状態.
     - otherwise: orange generic incident.
   - We keep timestamped raw HTML logs as `iijmiotrblbot-YYYYMMDD-HHMMSS.log` for auditing and diffing. `.gitignore` excludes these via `iijmiotrblbot-*.log`.
+- The same raw HTML logging pattern is applied to OCN Mobile ONE bot, writing `ocnmobileonebot-YYYYMMDD-HHMMSS.log` and ignoring via `ocnmobileonebot-*.log`.
+- When creating PRs with GitHub CLI, pass multi-line bodies via `--body-file` to avoid literal `\n` in the description.
 - Multiple data sources per Twitter account: Confirmed pattern remains valid; scripts with different case variations (e.g., `IIJMIOTRBLBot.sh` and `IIJmioTrblBot.sh`) post to the same account while maintaining separate `.now/.last` histories.
 
 ### Adding New Bots

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ environment
 .*-last
 .*.json
 iijmiotrblbot-*.log
+ocnmobileonebot-*.log

--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -4,7 +4,15 @@ set -u
 red=🔴
 green=🟢
 white=⚪
-result=$(curl -s -S "https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href="([^"]+)".+/\1/')/" | grep '<h1 class="p-template__type1">' -A 20 | sed -E -e "s/(<br>)+/\n/g" -e "s/^\\s+//" -e "s/<[^>]+>//g" -e "/^$/d" | tail -n +3)
+url="https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href=\"([^\"]+)\".+/\1/')/"
+raw_content=$(curl -s -S "$url")
+timestamp=$(date +"%Y%m%d-%H%M%S")
+log_file="ocnmobileonebot-${timestamp}.log"
+latest_log=$(ls -t ocnmobileonebot-*.log 2>/dev/null | head -1)
+if ! [ -f "$latest_log" ] || ! printf "%s" "$raw_content" | diff -q "$latest_log" - >/dev/null 2>&1; then
+	printf "%s" "$raw_content" >"$log_file"
+fi
+result=$(printf "%s" "$raw_content" | grep '<h1 class="p-template__type1">' -A 20 | sed -E -e "s/(<br>)+/\n/g" -e "s/^\\s+//" -e "s/<[^>]+>//g" -e "/^$/d" | tail -n +3)
 if tail -2 <<<"$result" | grep 回復済み >/dev/null; then
 	echo -n "$green"
 elif echo "$result" | grep -E "(発生日時.*変更|変更.*発生日時|■変更前|■変更後|日時.*変更.*いたしました)" >/dev/null; then

--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -6,6 +6,10 @@ green=🟢
 white=⚪
 url="https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href=\"([^\"]+)\".+/\1/')/"
 raw_content=$(curl -s -S "$url")
+if [ -z "$raw_content" ]; then
+	echo "Error: Failed to fetch content from $url" >&2
+	exit 1
+fi
 timestamp=$(date +"%Y%m%d-%H%M%S")
 log_file="ocnmobileonebot-${timestamp}.log"
 latest_log=$(ls -t ocnmobileonebot-*.log 2>/dev/null | head -1)


### PR DESCRIPTION
This PR adds raw HTML logging to OcnMobileOneBot.sh consistent with IIJmioTrblBot.sh:

- Fetches the resolved detail page URL and saves HTML to timestamped ocnmobileonebot-YYYYMMDD-HHMMSS.log files.
- Logs only when content changed (compares against the latest log).
- Parses from the saved raw HTML content instead of a fresh curl directly.
- Adds ocnmobileonebot-*.log to .gitignore.

Motivation: Keep an auditable history for parsing/regression analysis and easier diffing of source changes over time.

Please review.