### PR TITLE
ci(deploy): tolerate missing backup paths in cleanup step to prevent CI failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Creating backup..."
           cp -r . ../zenjiro-bot-oci-backup-$(date +%Y%m%d-%H%M%S)
           echo "Cleaning up old backups..."
-          find .. -name 'zenjiro-bot-oci-backup-*' -mtime +7 -exec rm -rf {} \;
+          find .. -ignore_readdir_race -maxdepth 1 -type d -name 'zenjiro-bot-oci-backup-*' -mtime +7 -exec rm -rf {} + 2>/dev/null || true
           echo "Pulling latest changes from GitHub..."
           git fetch origin
           git reset --hard origin/main


### PR DESCRIPTION
This PR fixes a failure in the Deploy to Oracle Cloud VM workflow where the backup cleanup step could exit non-zero when matching directories were not present.

Changes:
- Use safer find options:
  - limit to parent directory and type d
  - ignore readdir race conditions
  - batch delete with +
- Suppress non-critical errors and do not fail the job when nothing is found (2>/dev/null || true).

Rationale:
- The absence of older backup directories should not cause deployment to fail.
- Reduces flakiness due to transient filesystem races.

Please review and merge to restore green CI for deploy workflow on main.