### PR TITLE
docs(agent): add branching policy (no direct commits to main)

### DIFF
--- a/.agent.md
+++ b/.agent.md
@@ -180,6 +180,10 @@ export $(xargs < environment) && ./run-all.sh
   - We keep timestamped raw HTML logs as `iijmiotrblbot-YYYYMMDD-HHMMSS.log` for auditing and diffing. `.gitignore` excludes these via `iijmiotrblbot-*.log`.
 - The same raw HTML logging pattern is applied to OCN Mobile ONE bot, writing `ocnmobileonebot-YYYYMMDD-HHMMSS.log` and ignoring via `ocnmobileonebot-*.log`.
 - When creating PRs with GitHub CLI, pass multi-line bodies via `--body-file` to avoid literal `\n` in the description.
+- Always create a new branch before staging or committing any changes. Do not commit directly to `main`. Typical flow:
+  - `git checkout -b <feature-or-fix-branch>`
+  - make changes, then `git add ... && git commit -m "..."`
+  - `git push -u origin <feature-or-fix-branch>` and open a PR
 - Multiple data sources per Twitter account: Confirmed pattern remains valid; scripts with different case variations (e.g., `IIJMIOTRBLBot.sh` and `IIJmioTrblBot.sh`) post to the same account while maintaining separate `.now/.last` histories.
 
 ### Adding New Bots


### PR DESCRIPTION
Documented the rule to always create a new branch before staging/committing changes and to avoid committing directly to main.