### PR TITLE
OcnMobileOneBot: trim 【更新】 header block

### DIFF
--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -17,6 +17,7 @@ if ! [ -f "$latest_log" ] || ! printf "%s" "$raw_content" | diff -q "$latest_log
 	printf "%s" "$raw_content" >"$log_file"
 fi
 result=$(printf "%s" "$raw_content" | grep '<h1 class="p-template__type1">' -A 20 | sed -E -e "s/(<br>)+/\n/g" -e "s/^\\s+//" -e "s/<[^>]+>//g" -e "/^$/d" | tail -n +3)
+display=$(sed -E '/^【更新】$/,/^-+$/d' <<<"$result")
 if tail -2 <<<"$result" | grep 回復済み >/dev/null; then
 	echo -n "$green"
 elif echo "$result" | grep -E "(発生日時.*変更|変更.*発生日時|■変更前|■変更後|日時.*変更.*いたしました)" >/dev/null; then
@@ -24,4 +25,4 @@ elif echo "$result" | grep -E "(発生日時.*変更|変更.*発生日時|■変
 else
 	echo -n "$red"
 fi
-head -n -6 <<<"$result"
+head -n -6 <<<"$display"


### PR DESCRIPTION
This change trims the initial '【更新】 ... ■変更前/■変更後 ... -----' section from the displayed content in OcnMobileOneBot.sh.

- Keeps existing status colors:
  - green on 回復済み
  - white on 発生日時変更/■変更前/■変更後 patterns
  - red otherwise
- Only affects the text displayed (uses a new variable 'display'); status detection still checks full 'result' to keep behavior consistent.

This addresses the request to focus on the essential notice text and omit the timestamp update details and horizontal rule.