### PR TITLE
fix(truncate): select longest valid prefix up to 280 weighted chars

### DIFF
--- a/truncate.py
+++ b/truncate.py
@@ -1,8 +1,8 @@
 import sys
 from twitter_text import parse_tweet
 
-s = "".join(sys.stdin.readlines()).rstrip()
-for i in range(0, len(s)):
-    if parse_tweet(s[:-i]).weightedLength <= 280:
-        print(s[:-i])
+s = sys.stdin.read().rstrip()
+for i in range(len(s), -1, -1):
+    if parse_tweet(s[:i]).weightedLength <= 280:
+        print(s[:i])
         break


### PR DESCRIPTION
This PR fixes `truncate.py` so it:

- Reads stdin once and strips only trailing whitespace/newlines
- Iterates from full length to 0 to find the longest valid prefix whose `twitter_text` weighted length is <= 280
- Avoids truncation when the input is already within the limit

Why
- The previous change always removed at least one character and did not handle already-valid inputs, causing unnecessary truncation.
- This ensures our bot tweets preserve as much content as possible while respecting Twitter's weighting rules.

Implementation notes
- Keeps internal newlines intact; only trims trailing whitespace/newlines to avoid accidental extra characters.
- Compatible with the existing `run-all.sh` pipeline (`uv run truncate.py`).

Testing
- Verified locally by feeding sample inputs that are:
  - already <= 280 weighted chars (no truncation)
  - slightly > 280 (truncates to the longest valid prefix)

Please review.
