### PR TITLE
OCN Mobile ONE: follow redirects when fetching detail page

### DIFF
--- a/OcnMobileOneBot.sh
+++ b/OcnMobileOneBot.sh
@@ -5,7 +5,7 @@ red=🔴
 green=🟢
 white=⚪
 url="https://support.ocn.ne.jp/$(curl -s -S https://support.ocn.ne.jp/mobile-one/ | grep 現在対応中の工事・故障情報 -A 9 | tail -1 | sed -E -e 's/.+<a href=\"([^\"]+)\".+/\1/')/"
-raw_content=$(curl -s -S "$url")
+raw_content=$(curl -s -S --location "$url")
 if [ -z "$raw_content" ]; then
 	echo "Error: Failed to fetch content from $url" >&2
 	exit 1


### PR DESCRIPTION
Fix: OCN Mobile ONE bot follows redirects when fetching detail page

Problem
- The detail URL extracted from the OCN Mobile ONE listing sometimes includes a double or missing slash pattern that results in a 301 Moved Permanently response when fetched directly.

Change
- Add `--location` flag to the curl call fetching the detail page content in `OcnMobileOneBot.sh` so that 30x redirects are followed and the actual page content is retrieved.

Why
- Without following redirects, the bot receives a 301 HTML body and can fail parsing or treat it as empty/invalid content.

Scope
- Minimal change: only the detail fetch is updated. No behavior changes to parsing, formatting, or logging.

Notes
- Consider also normalizing the constructed URL (avoid trailing slash concatenation) and adding `--location` to the initial index fetch in a follow-up.

Fixes #58
