### PR TITLE
feat(workflows): trigger Gemini CLI on PR opened with @gemini-cli in body

### DIFF
--- a/.github/workflows/gemini-cli.yml
+++ b/.github/workflows/gemini-cli.yml
@@ -10,6 +10,9 @@ on:
   issue_comment:
     types:
       - 'created'
+  pull_request:
+    types:
+      - 'opened'
   issues:
     types:
       - 'opened'
@@ -56,6 +59,19 @@ jobs:
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
             github.event.comment.author_association == 'COLLABORATOR'
+          )
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request' && github.event.action == 'opened' &&
+        contains(github.event.pull_request.body, '@gemini-cli') &&
+        !contains(github.event.pull_request.body, '/review') &&
+        !contains(github.event.pull_request.body, '/triage') &&
+        (
+          github.event.sender.type == 'User' && (
+            github.event.pull_request.author_association == 'OWNER' ||
+            github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'COLLABORATOR'
           )
         )
       ) ||
@@ -124,6 +140,10 @@ jobs:
             IS_PR="true"
           elif [[ "${EVENT_NAME}" == "pull_request_review_comment" ]]; then
             USER_REQUEST=$(echo "${EVENT_PAYLOAD}" | jq -r .comment.body)
+            ISSUE_NUMBER=$(echo "${EVENT_PAYLOAD}" | jq -r .pull_request.number)
+            IS_PR="true"
+          elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            USER_REQUEST=$(echo "${EVENT_PAYLOAD}" | jq -r .pull_request.body)
             ISSUE_NUMBER=$(echo "${EVENT_PAYLOAD}" | jq -r .pull_request.number)
             IS_PR="true"
           fi


### PR DESCRIPTION
Enable the Gemini CLI workflow to run when a pull request is opened and the PR body contains `@gemini-cli`.

Changes:
- Add `pull_request: [opened]` to the workflow triggers
- Extend the job `if:` to handle `pull_request.opened` with `@gemini-cli` and exclude `/review` and `/triage`
- Update `get_context` to parse PR body and mark `is_pr=true`

Notes:
- Still restricted to OWNER/MEMBER/COLLABORATOR initiators.
- Keeps existing comment/review triggers intact.
